### PR TITLE
Update fee handler interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8170,7 +8170,6 @@ name = "sygma-traits"
 version = "0.1.0"
 dependencies = [
  "frame-support",
- "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "xcm",

--- a/basic-fee-handler/src/lib.rs
+++ b/basic-fee-handler/src/lib.rs
@@ -69,11 +69,7 @@ pub mod pallet {
 	pub struct BasicFeeHandlerImpl<T>(PhantomData<T>);
 
 	impl<T: Config> FeeHandler for BasicFeeHandlerImpl<T> {
-		fn new() -> Self {
-			Self(PhantomData)
-		}
-
-		fn get_fee(&self, asset: AssetId) -> Option<u128> {
+		fn get_fee(asset: &AssetId) -> Option<u128> {
 			AssetFees::<T>::get(asset)
 		}
 	}

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive", "serde", "decode"] }
-impl-trait-for-tuples = "0.2.2"
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30", default-features = false }
 
 # Polkadot

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -7,22 +7,6 @@ pub type DepositNonce = u64;
 pub type ResourceId = [u8; 32];
 
 pub trait FeeHandler: Sized {
-	/// Create a new trader instance.
-	fn new() -> Self;
-
 	// Return fee represent by a specific asset
-	fn get_fee(&self, asset_id: AssetId) -> Option<u128>;
-}
-
-#[allow(clippy::unused_unit)]
-#[impl_trait_for_tuples::impl_for_tuples(30)]
-impl FeeHandler for Tuple {
-	fn new() -> Self {
-		for_tuples!( ( #( Tuple::new() ),* ) )
-	}
-
-	fn get_fee(&self, asset_id: AssetId) -> Option<u128> {
-		// TODO
-		None
-	}
+	fn get_fee(asset_id: &AssetId) -> Option<u128>;
 }


### PR DESCRIPTION
We found there is not necessary to make a FeeHandler can be initialized to an object, so we removed `new` from the trait definition.
And multiple fee handler also is not a requirement so far, delete the tuple thing too.