### PR TITLE
feat: Multi domain support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty",
+ "funty 2.0.0",
  "radium",
  "tap",
  "wyz",
@@ -2010,6 +2010,12 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "funty"
+version = "3.0.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d938e9fbe98b5b9d7064e363900acbd810c0a56898480d90837a7e9947b10ef8"
 
 [[package]]
 name = "futures"
@@ -3877,6 +3883,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "funty 3.0.0-rc1",
  "hex",
  "hex-literal",
  "pallet-assets",
@@ -7648,6 +7655,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "funty 3.0.0-rc1",
  "hex-literal",
  "log",
  "pallet-assets",

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,8 @@ build-e2e-test-docker-image:
 # run the preconfigured e2e docker image
 start-e2e-image:
 	 docker run -p 9944:9944 -it sygma_substrate_pallets_e2e_preconfigured
+
+# run setup js script to setup the local substrate node
+# substrate node is required, run make start-dev first
+run-setup:
+	node ./scripts/js/setup.js

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
+# run cargo clippy and cargo fmt
 lint: fmt
 	cargo fmt --all --check
 	cargo clippy --all-targets -- -D warnings
 
+# run cargo fmt
 fmt:
 	cargo fmt --all
 
+# run unit test
 test:
 	cargo test
 
+# build the binary locally
 build:
 	cargo build --release
 
+# launch the local node in dev mode
 start-dev:
 	./target/release/node-template --dev --ws-external
 

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -12,6 +12,7 @@ eth-encode-packed = { version =  "0.1.0", default-features = false }
 ethabi = { version = "18.0.0", default-features = false }
 primitive-types = { version = "0.12", default-features = false, features = ["scale-info", "serde_no_std"] }
 arrayref = { version = "0.3.6", default-features = false }
+funty = { version = "3.0.0-rc1", default-features = false }
 
 # Substrate
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -795,15 +795,15 @@ pub mod pallet {
 
 	#[cfg(test)]
 	mod test {
-		use alloc::vec;
 		use crate as bridge;
 		use crate::{Event as SygmaBridgeEvent, IsPaused, MpcAdd, Proposal};
+		use alloc::vec;
 		use bridge::mock::{
 			assert_events, new_test_ext, AccessSegregator, Assets, Balances, BridgeAccount,
 			BridgePalletIndex, NativeLocation, NativeResourceId, Runtime, RuntimeEvent,
 			RuntimeOrigin as Origin, SygmaBasicFeeHandler, SygmaBridge, TreasuryAccount,
-			UsdcAssetId, UsdcLocation, UsdcResourceId, ALICE, ASSET_OWNER, BOB, ENDOWED_BALANCE,
-			DEST_DOMAIN_ID,
+			UsdcAssetId, UsdcLocation, UsdcResourceId, ALICE, ASSET_OWNER, BOB, DEST_DOMAIN_ID,
+			ENDOWED_BALANCE,
 		};
 		use codec::Encode;
 		use frame_support::{
@@ -852,7 +852,6 @@ pub mod pallet {
 				let default_addr = MpcAddress::default();
 				let test_mpc_addr_a: MpcAddress = MpcAddress([1u8; 20]);
 
-
 				assert_eq!(MpcAdd::<Runtime>::get(), default_addr);
 
 				// pause bridge when mpc address is not set, should be err
@@ -865,7 +864,11 @@ pub mod pallet {
 				assert_ok!(SygmaBridge::set_mpc_address(Origin::root(), test_mpc_addr_a));
 				assert_eq!(MpcAdd::<Runtime>::get(), test_mpc_addr_a);
 				// register domain
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// pause bridge again, should be ok
 				assert_ok!(SygmaBridge::pause_bridge(Origin::root(), DEST_DOMAIN_ID));
@@ -909,7 +912,11 @@ pub mod pallet {
 				assert_ok!(SygmaBridge::set_mpc_address(Origin::root(), test_mpc_addr_a));
 				assert_eq!(MpcAdd::<Runtime>::get(), test_mpc_addr_a);
 				// register domain
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				assert_ok!(SygmaBridge::pause_bridge(Origin::root(), DEST_DOMAIN_ID));
 				assert_events(vec![RuntimeEvent::SygmaBridge(SygmaBridgeEvent::BridgePaused {
@@ -1086,17 +1093,23 @@ pub mod pallet {
 					NativeLocation::get().into(),
 					fee
 				));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				assert_ok!(SygmaBridge::deposit(
 					Origin::signed(ALICE),
 					(Concrete(NativeLocation::get()), Fungible(amount)).into(),
 					(
 						0,
-						X2(GeneralKey(
-							WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-						),
-						GeneralIndex(1))
+						X2(
+							GeneralKey(
+								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
+							),
+							GeneralIndex(1)
+						)
 					)
 						.into(),
 				));
@@ -1134,7 +1147,11 @@ pub mod pallet {
 					UsdcLocation::get().into(),
 					fee
 				));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// Register foreign asset (USDC) with asset id 0
 				assert_ok!(<pallet_assets::pallet::Pallet<Runtime> as FungibleCerate<
@@ -1150,9 +1167,12 @@ pub mod pallet {
 					(Concrete(UsdcLocation::get()), Fungible(amount)).into(),
 					(
 						0,
-						X2(GeneralKey(
-							WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-						), GeneralIndex(1))
+						X2(
+							GeneralKey(
+								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
+							),
+							GeneralIndex(1)
+						)
 					)
 						.into(),
 				));
@@ -1191,7 +1211,11 @@ pub mod pallet {
 					unbounded_asset_location.clone().into(),
 					fee
 				));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				assert_noop!(
 					SygmaBridge::deposit(
@@ -1199,9 +1223,13 @@ pub mod pallet {
 						(Concrete(unbounded_asset_location), Fungible(amount)).into(),
 						(
 							0,
-							X2(GeneralKey(
-								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-							), GeneralIndex(1))
+							X2(
+								GeneralKey(
+									WeakBoundedVec::try_from(b"ethereum recipient".to_vec())
+										.unwrap()
+								),
+								GeneralIndex(1)
+							)
 						)
 							.into(),
 					),
@@ -1233,7 +1261,11 @@ pub mod pallet {
 					NativeLocation::get().into(),
 					fee
 				));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				assert_noop!(
 					SygmaBridge::deposit(
@@ -1252,16 +1284,24 @@ pub mod pallet {
 				let test_mpc_addr: MpcAddress = MpcAddress([1u8; 20]);
 				let amount = 200u128;
 				assert_ok!(SygmaBridge::set_mpc_address(Origin::root(), test_mpc_addr));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 				assert_noop!(
 					SygmaBridge::deposit(
 						Origin::signed(ALICE),
 						(Concrete(NativeLocation::get()), Fungible(amount)).into(),
 						(
 							0,
-							X2(GeneralKey(
-								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-							), GeneralIndex(1))
+							X2(
+								GeneralKey(
+									WeakBoundedVec::try_from(b"ethereum recipient".to_vec())
+										.unwrap()
+								),
+								GeneralIndex(1)
+							)
 						)
 							.into(),
 					),
@@ -1284,16 +1324,24 @@ pub mod pallet {
 					NativeLocation::get().into(),
 					fee
 				));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 				assert_noop!(
 					SygmaBridge::deposit(
 						Origin::signed(ALICE),
 						(Concrete(NativeLocation::get()), Fungible(amount)).into(),
 						(
 							0,
-							X2(GeneralKey(
-								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-							), GeneralIndex(1))
+							X2(
+								GeneralKey(
+									WeakBoundedVec::try_from(b"ethereum recipient".to_vec())
+										.unwrap()
+								),
+								GeneralIndex(1)
+							)
 						)
 							.into(),
 					),
@@ -1317,7 +1365,11 @@ pub mod pallet {
 					fee
 				));
 				// register domain
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// Pause bridge
 				assert_ok!(SygmaBridge::pause_bridge(Origin::root(), DEST_DOMAIN_ID));
@@ -1328,9 +1380,13 @@ pub mod pallet {
 						(Concrete(NativeLocation::get()), Fungible(amount)).into(),
 						(
 							0,
-							X2(GeneralKey(
-								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-							), GeneralIndex(1))
+							X2(
+								GeneralKey(
+									WeakBoundedVec::try_from(b"ethereum recipient".to_vec())
+										.unwrap()
+								),
+								GeneralIndex(1)
+							)
 						)
 							.into(),
 					),
@@ -1344,9 +1400,12 @@ pub mod pallet {
 					(Concrete(NativeLocation::get()), Fungible(amount)).into(),
 					(
 						0,
-						X2(GeneralKey(
-							WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-						), GeneralIndex(1))
+						X2(
+							GeneralKey(
+								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
+							),
+							GeneralIndex(1)
+						)
 					)
 						.into(),
 				));
@@ -1358,7 +1417,6 @@ pub mod pallet {
 			new_test_ext().execute_with(|| {
 				let fee = 200u128;
 				let amount = 100u128;
-
 
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
@@ -1372,9 +1430,13 @@ pub mod pallet {
 						(Concrete(NativeLocation::get()), Fungible(amount)).into(),
 						(
 							0,
-							X2(GeneralKey(
-								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-							), GeneralIndex(1))
+							X2(
+								GeneralKey(
+									WeakBoundedVec::try_from(b"ethereum recipient".to_vec())
+										.unwrap()
+								),
+								GeneralIndex(1)
+							)
 						)
 							.into(),
 					),
@@ -1388,19 +1450,33 @@ pub mod pallet {
 			new_test_ext().execute_with(|| {
 				// mpc address is missing, should fail
 				assert_noop!(
-					SygmaBridge::retry(Origin::signed(ALICE), 1234567u128, 1234u128, DEST_DOMAIN_ID),
+					SygmaBridge::retry(
+						Origin::signed(ALICE),
+						1234567u128,
+						1234u128,
+						DEST_DOMAIN_ID
+					),
 					bridge::Error::<Runtime>::MissingMpcAddress
 				);
 
 				// set mpc address
 				let test_mpc_addr: MpcAddress = MpcAddress([1u8; 20]);
 				assert_ok!(SygmaBridge::set_mpc_address(Origin::root(), test_mpc_addr));
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// pause bridge and retry, should fail
 				assert_ok!(SygmaBridge::pause_bridge(Origin::root(), DEST_DOMAIN_ID));
 				assert_noop!(
-					SygmaBridge::retry(Origin::signed(ALICE), 1234567u128, 1234u128, DEST_DOMAIN_ID),
+					SygmaBridge::retry(
+						Origin::signed(ALICE),
+						1234567u128,
+						1234u128,
+						DEST_DOMAIN_ID
+					),
 					bridge::Error::<Runtime>::BridgePaused
 				);
 
@@ -1409,7 +1485,12 @@ pub mod pallet {
 				assert!(!IsPaused::<Runtime>::get(DEST_DOMAIN_ID));
 
 				// retry again, should work
-				assert_ok!(SygmaBridge::retry(Origin::signed(ALICE), 1234567u128, 1234u128, DEST_DOMAIN_ID));
+				assert_ok!(SygmaBridge::retry(
+					Origin::signed(ALICE),
+					1234567u128,
+					1234u128,
+					DEST_DOMAIN_ID
+				));
 				assert_events(vec![RuntimeEvent::SygmaBridge(SygmaBridgeEvent::Retry {
 					deposit_on_block_height: 1234567u128,
 					deposit_extrinsic_index: 1234u128,
@@ -1432,7 +1513,11 @@ pub mod pallet {
 				assert_ok!(SygmaBridge::set_mpc_address(Origin::root(), test_mpc_addr));
 				assert_eq!(MpcAdd::<Runtime>::get(), test_mpc_addr);
 				// register domain
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// Generate an evil key
 				let (evil_pair, _): (ecdsa::Pair, _) = Pair::generate();
@@ -1451,9 +1536,12 @@ pub mod pallet {
 					(Concrete(NativeLocation::get()), Fungible(2 * amount)).into(),
 					(
 						0,
-						X2(GeneralKey(
-							WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
-						), GeneralIndex(1))
+						X2(
+							GeneralKey(
+								WeakBoundedVec::try_from(b"ethereum recipient".to_vec()).unwrap()
+							),
+							GeneralIndex(1)
+						)
 					)
 						.into(),
 				));
@@ -1539,16 +1627,18 @@ pub mod pallet {
 				assert_ok!(SygmaBridge::pause_bridge(Origin::root(), DEST_DOMAIN_ID));
 				assert!(IsPaused::<Runtime>::get(DEST_DOMAIN_ID));
 				assert_ok!(SygmaBridge::execute_proposal(
-						Origin::signed(ALICE),
-						proposals.clone(),
-						proposals_with_valid_signature.encode())
-				);
+					Origin::signed(ALICE),
+					proposals.clone(),
+					proposals_with_valid_signature.encode()
+				));
 				// should emit FailedHandlerExecution event
-				assert_events(vec![RuntimeEvent::SygmaBridge(SygmaBridgeEvent::FailedHandlerExecution {
-				 	error: vec![66, 114, 105, 100, 103, 101, 80, 97, 117, 115, 101, 100],
-					origin_domain_id: 1,
-					deposit_nonce: 3,
-				})]);
+				assert_events(vec![RuntimeEvent::SygmaBridge(
+					SygmaBridgeEvent::FailedHandlerExecution {
+						error: vec![66, 114, 105, 100, 103, 101, 80, 97, 117, 115, 101, 100],
+						origin_domain_id: 1,
+						deposit_nonce: 3,
+					},
+				)]);
 				assert_ok!(SygmaBridge::unpause_bridge(Origin::root(), DEST_DOMAIN_ID));
 
 				assert_noop!(
@@ -1584,7 +1674,11 @@ pub mod pallet {
 				let test_mpc_addr: MpcAddress = MpcAddress([1u8; 20]);
 				assert_ok!(SygmaBridge::set_mpc_address(Origin::root(), test_mpc_addr));
 				// register domain
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// pause bridge
 				assert_ok!(SygmaBridge::pause_bridge(Origin::root(), DEST_DOMAIN_ID));
@@ -1644,7 +1738,11 @@ pub mod pallet {
 				// ALICE set mpc address should work
 				assert_ok!(SygmaBridge::set_mpc_address(Some(ALICE).into(), test_mpc_addr));
 				// register domain
-				assert_ok!(SygmaBridge::register_domain(Origin::root(), DEST_DOMAIN_ID, U256::from(1)));
+				assert_ok!(SygmaBridge::register_domain(
+					Origin::root(),
+					DEST_DOMAIN_ID,
+					U256::from(1)
+				));
 
 				// ALICE pause&unpause bridge should still failed
 				assert_noop!(

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -82,6 +82,11 @@ pub mod pallet {
 		#[pallet::constant]
 		type DestVerifyingContractAddress: Get<VerifyingContractAddress>;
 
+		/// Pallet ChainID
+		/// This is used in EIP712 typed data domain
+		#[pallet::constant]
+		type EIP712ChainID: Get<ChainID>;
+
 		/// Fee reserve account
 		#[pallet::constant]
 		type FeeReserveAccount: Get<Self::AccountId>;
@@ -526,7 +531,7 @@ pub mod pallet {
 				Error::<T>::BadMpcSignature
 			);
 
-			// Execute proposals one by on.
+			// Execute proposals one by one.
 			// Note if one proposal failed to execute, we emit `FailedHandlerExecution` rather
 			// than revert whole transaction
 			for proposal in proposals.iter() {
@@ -617,8 +622,6 @@ pub mod pallet {
 				return [0u8; 32]
 			}
 
-			let chain_id: ChainID = DestChainIds::<T>::get(proposals[0].origin_domain_id);
-
 			let mut keccak_data = Vec::new();
 			for prop in proposals {
 				let proposal_domain_id_token = Token::Uint(prop.origin_domain_id.into());
@@ -657,7 +660,7 @@ pub mod pallet {
 			let eip712_domain = eip712::EIP712Domain {
 				name: String::from("Bridge"),
 				version: String::from("3.1.0"),
-				chain_id,
+				chain_id: T::EIP712ChainID::get(),
 				verifying_contract: T::DestVerifyingContractAddress::get(),
 				salt: default_eip712_domain.salt,
 			};

--- a/bridge/src/mock.rs
+++ b/bridge/src/mock.rs
@@ -154,6 +154,8 @@ parameter_types! {
 		(BridgePalletIndex::get(), b"set_mpc_address".to_vec()),
 		(BridgePalletIndex::get(), b"pause_bridge".to_vec()),
 		(BridgePalletIndex::get(), b"unpause_bridge".to_vec()),
+		(BridgePalletIndex::get(), b"register_domain".to_vec()),
+		(BridgePalletIndex::get(), b"unregister_domain".to_vec()),
 	].to_vec();
 }
 
@@ -171,9 +173,7 @@ impl sygma_basic_feehandler::Config for Runtime {
 }
 
 parameter_types! {
-	pub DestDomainID: DomainID = 1;
 	pub TreasuryAccount: AccountId32 = AccountId32::new([100u8; 32]);
-	pub DestChainID: ChainID = primitive_types::U256([1u64; 4]);
 	pub DestVerifyingContractAddress: VerifyingContractAddress = primitive_types::H160([1u8; 20]);
 	pub BridgeAccount: AccountId32 = AccountId32::new([101u8; 32]);
 	pub CheckingAccount: AccountId32 = AccountId32::new([102u8; 32]);
@@ -298,10 +298,8 @@ impl ExtractRecipient for RecipientParser {
 impl sygma_bridge::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type DestDomainID = DestDomainID;
 	type TransferReserveAccount = BridgeAccount;
 	type FeeReserveAccount = TreasuryAccount;
-	type DestChainID = DestChainID;
 	type DestVerifyingContractAddress = DestVerifyingContractAddress;
 	type FeeHandler = SygmaBasicFeeHandler;
 	type AssetTransactor = AssetTransactors;

--- a/bridge/src/mock.rs
+++ b/bridge/src/mock.rs
@@ -6,7 +6,7 @@
 use crate as sygma_bridge;
 use funty::Fundamental;
 use sygma_traits::{
-	DomainID, ExtractDestDomainID, ExtractRecipient, IsReserved, ResourceId,
+	ChainID, DomainID, ExtractDestDomainID, ExtractRecipient, IsReserved, ResourceId,
 	VerifyingContractAddress,
 };
 
@@ -176,6 +176,7 @@ impl sygma_basic_feehandler::Config for Runtime {
 
 parameter_types! {
 	pub TreasuryAccount: AccountId32 = AccountId32::new([100u8; 32]);
+	pub EIP712ChainID: ChainID = primitive_types::U256([1u64; 4]);
 	pub DestVerifyingContractAddress: VerifyingContractAddress = primitive_types::H160([1u8; 20]);
 	pub BridgeAccount: AccountId32 = AccountId32::new([101u8; 32]);
 	pub CheckingAccount: AccountId32 = AccountId32::new([102u8; 32]);
@@ -314,6 +315,7 @@ impl sygma_bridge::Config for Runtime {
 	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type TransferReserveAccount = BridgeAccount;
 	type FeeReserveAccount = TreasuryAccount;
+	type EIP712ChainID = EIP712ChainID;
 	type DestVerifyingContractAddress = DestVerifyingContractAddress;
 	type FeeHandler = SygmaBasicFeeHandler;
 	type AssetTransactor = AssetTransactors;

--- a/bridge/src/mock.rs
+++ b/bridge/src/mock.rs
@@ -292,7 +292,7 @@ impl ExtractRecipient for RecipientParser {
 	fn extract_recipient(dest: &MultiLocation) -> Option<Vec<u8>> {
 		// For example, we force a dest location should be represented by following format.
 		match (dest.parents, &dest.interior) {
-			(0, Junctions::X2(GeneralKey(recipient), GeneralKey(_dest_domain_id))) =>
+			(0, Junctions::X2(GeneralKey(recipient), GeneralIndex(_dest_domain_id))) =>
 				Some(recipient.to_vec()),
 			_ => None,
 		}

--- a/bridge/src/mock.rs
+++ b/bridge/src/mock.rs
@@ -331,6 +331,7 @@ pub const ALICE: AccountId32 = AccountId32::new([0u8; 32]);
 pub const ASSET_OWNER: AccountId32 = AccountId32::new([1u8; 32]);
 pub const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 pub const ENDOWED_BALANCE: Balance = 100_000_000;
+pub const DEST_DOMAIN_ID: DomainID = 1;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();

--- a/bridge/src/mock.rs
+++ b/bridge/src/mock.rs
@@ -6,8 +6,7 @@
 use crate as sygma_bridge;
 use funty::Fundamental;
 use sygma_traits::{
-	ChainID, DomainID, ExtractDestDomainID, ExtractRecipient, IsReserved, ResourceId,
-	VerifyingContractAddress,
+	ChainID, DomainID, ExtractDestinationData, IsReserved, ResourceId, VerifyingContractAddress,
 };
 
 use frame_support::{
@@ -287,24 +286,12 @@ impl IsReserved for ReserveChecker {
 }
 
 // Project can have it's own implementation to adapt their own spec design.
-pub struct RecipientParser;
-impl ExtractRecipient for RecipientParser {
-	fn extract_recipient(dest: &MultiLocation) -> Option<Vec<u8>> {
-		// For example, we force a dest location should be represented by following format.
+pub struct DestinationDataParser;
+impl ExtractDestinationData for DestinationDataParser {
+	fn extract_dest(dest: &MultiLocation) -> Option<(Vec<u8>, DomainID)> {
 		match (dest.parents, &dest.interior) {
-			(0, Junctions::X2(GeneralKey(recipient), GeneralIndex(_dest_domain_id))) =>
-				Some(recipient.to_vec()),
-			_ => None,
-		}
-	}
-}
-
-pub struct DestDomainIDParser;
-impl ExtractDestDomainID for DestDomainIDParser {
-	fn extract_dest_domain_id(dest: &MultiLocation) -> Option<DomainID> {
-		match (dest.parents, &dest.interior) {
-			(0, Junctions::X2(GeneralKey(_recipient), GeneralIndex(dest_domain_id))) =>
-				Some(dest_domain_id.as_u8()),
+			(0, Junctions::X2(GeneralKey(recipient), GeneralIndex(dest_domain_id))) =>
+				Some((recipient.to_vec(), dest_domain_id.as_u8())),
 			_ => None,
 		}
 	}
@@ -321,8 +308,7 @@ impl sygma_bridge::Config for Runtime {
 	type AssetTransactor = AssetTransactors;
 	type ResourcePairs = ResourcePairs;
 	type ReserveChecker = ReserveChecker;
-	type ExtractDestDomainID = DestDomainIDParser;
-	type ExtractRecipient = RecipientParser;
+	type ExtractDestData = DestinationDataParser;
 	type PalletId = SygmaBridgePalletId;
 	type PalletIndex = BridgePalletIndex;
 }

--- a/scripts/js/setup.js
+++ b/scripts/js/setup.js
@@ -13,9 +13,12 @@ const feeHandlerType = {
 
 const supportedDestDomains = [
     {
-        evmDomain: {
-            domainID: 1
-        }
+        domainID: 1,
+        chainID: 1
+    },
+    {
+        domainID: 2,
+        chainID: 2
     }
 ]
 
@@ -61,7 +64,7 @@ async function setFeeHandler(api, domainID, asset, feeHandlerType, finalization,
         const nonce = Number((await api.query.system.account(sudo.address)).nonce);
 
         console.log(
-            `--- Submitting extrinsic to set fee handler. (nonce: ${nonce}) ---`
+            `--- Submitting extrinsic to set fee handler on domainID ${domainID}. (nonce: ${nonce}) ---`
         );
         const unsub = await api.tx.sudo
             .sudo(api.tx.feeHandlerRouter.setFeeHandler(domainID, asset, feeHandlerType))
@@ -96,7 +99,7 @@ async function setFee(api, domainID, asset, amount, finalization, sudo) {
         const nonce = Number((await api.query.system.account(sudo.address)).nonce);
 
         console.log(
-            `--- Submitting extrinsic to set basic fee. (nonce: ${nonce}) ---`
+            `--- Submitting extrinsic to set basic fee on domainID ${domainID}. (nonce: ${nonce}) ---`
         );
         const unsub = await api.tx.sudo
             .sudo(api.tx.sygmaBasicFeeHandler.setFee(domainID, asset, amount))
@@ -269,6 +272,41 @@ async function mintAsset(api, id, recipient, amount, finalization, sudo) {
     });
 }
 
+async function registerDomain(api, domainID, chainID, finalization, sudo) {
+    return new Promise(async (resolve, reject) => {
+        const nonce = Number((await api.query.system.account(sudo.address)).nonce);
+
+        console.log(
+            `--- Submitting extrinsic to register domainID ${domainID} with chainID ${chainID}. (nonce: ${nonce}) ---`
+        );
+        const unsub = await api.tx.sudo
+            .sudo(api.tx.sygmaBridge.registerDomain(domainID, chainID))
+            .signAndSend(sudo, {nonce: nonce, era: 0}, (result) => {
+                console.log(`Current status is ${result.status}`);
+                if (result.status.isInBlock) {
+                    console.log(
+                        `Transaction included at blockHash ${result.status.asInBlock}`
+                    );
+                    if (finalization) {
+                        console.log('Waiting for finalization...');
+                    } else {
+                        unsub();
+                        resolve();
+                    }
+                } else if (result.status.isFinalized) {
+                    console.log(
+                        `Transaction finalized at blockHash ${result.status.asFinalized}`
+                    );
+                    unsub();
+                    resolve();
+                } else if (result.isError) {
+                    console.log(`Transaction Error`);
+                    reject(`Transaction Error`);
+                }
+            });
+    });
+}
+
 function getUSDCAssetId(api) {
     return api.createType('XcmV1MultiassetAssetId', {
         Concrete: api.createType('XcmV1MultiLocation', {
@@ -318,9 +356,16 @@ async function main() {
     // set up MPC address
     await setMpcAddress(api, mpcAddr, true, sudo);
 
-    // set fee for native asset for domain 1
-    await setFeeHandler(api, supportedDestDomains[0].evmDomain.domainID, getNativeAssetId(api), feeHandlerType.BasicFeeHandler, true, sudo)
-    await setFee(api, supportedDestDomains[0].evmDomain.domainID, getNativeAssetId(api), basicFeeAmount, true, sudo);
+    // register dest domains
+    for (const domain of supportedDestDomains) {
+        await registerDomain(api, domain.domainID, domain.chainID, true, sudo);
+    }
+
+    // set fee for native asset for domains
+    for (const domain of supportedDestDomains) {
+        await setFeeHandler(api, domain.domainID, getNativeAssetId(api), feeHandlerType.BasicFeeHandler, true, sudo)
+        await setFee(api, domain.domainID, getNativeAssetId(api), basicFeeAmount, true, sudo);
+    }
 
     // create USDC test asset (foreign asset)
     // UsdcAssetId: AssetId defined in runtime.rs
@@ -334,22 +379,24 @@ async function main() {
     await setAssetMetadata(api, usdcAssetID, usdcName, usdcSymbol, usdcDecimal, true, sudo);
     await mintAsset(api, usdcAssetID, usdcAdmin, 100000000000000, true, sudo); // mint 100 USDC to Alice
 
-    // set fee for USDC for domain 1
-    await setFeeHandler(api, supportedDestDomains[0].evmDomain.domainID, getUSDCAssetId(api), feeHandlerType.BasicFeeHandler, true, sudo)
-    await setFee(api, supportedDestDomains[0].evmDomain.domainID, getUSDCAssetId(api), basicFeeAmount, true, sudo);
+    // set fee for USDC for domains
+    for (const domain of supportedDestDomains) {
+        await setFeeHandler(api, domain.domainID, getUSDCAssetId(api), feeHandlerType.BasicFeeHandler, true, sudo)
+        await setFee(api, domain.domainID, getUSDCAssetId(api), basicFeeAmount, true, sudo);
+    }
 
     // transfer some native asset to FeeReserveAccount as Existential Deposit(aka ED)
     await setBalance(api, FeeReserveAccountAddress, bn1e12.mul(new BN(10000)), true, sudo); // set balance to 10000 native asset
 
     // bridge should be unpaused by the end of the setup
     for (const domain of supportedDestDomains) {
-        if (!await queryBridgePauseStatus(api, domain.evmDomain.domainID)) console.log(`DestDomainID: ${domain.evmDomain.domainID} is ready✅`);
+        if (!await queryBridgePauseStatus(api, domain.domainID)) console.log(`DestDomainID: ${domain.domainID} is ready✅`);
     }
 
     console.log('🚀 Sygma substrate pallet setup is done! 🚀');
 
     // It is unnecessary to set up access segregator here since ALICE will be the sudo account and all methods with access control logic are already setup in this script.
-    // so that on Relayer, E2E test cases are only about public extrinsic such as deposit, executionProposal, retry .etc
+    // so that on Relayer, E2E test only cases about public extrinsic such as deposit, executionProposal, retry .etc
 }
 
 main().catch(console.error).finally(() => process.exit());

--- a/substrate-node/runtime/Cargo.toml
+++ b/substrate-node/runtime/Cargo.toml
@@ -15,9 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-hex-literal = "0.3"
+hex-literal = { version = "0.3", default-features = false }
 primitive-types = { version = "0.12", default-features = false, features = ["scale-info", "serde_no_std"] }
-hex = "0.4.3"
+hex = { version = "0.4.3", default-features = false }
+funty = { version = "3.0.0-rc1", default-features = false }
 
 pallet-assets = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33" }
 pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -508,7 +508,7 @@ impl ExtractRecipient for RecipientParser {
 	fn extract_recipient(dest: &MultiLocation) -> Option<Vec<u8>> {
 		// For example, we force a dest location should be represented by following format.
 		match (dest.parents, &dest.interior) {
-			(0, Junctions::X2(GeneralKey(recipient), GeneralKey(_dest_domain_id))) =>
+			(0, Junctions::X2(GeneralKey(recipient), GeneralIndex(_dest_domain_id))) =>
 				Some(recipient.to_vec()),
 			_ => None,
 		}

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -31,7 +31,7 @@ use sp_std::{borrow::Borrow, marker::PhantomData, prelude::*, result, vec::Vec};
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use sygma_traits::{
-	DomainID, ExtractDestDomainID, ExtractRecipient, IsReserved, ResourceId,
+	ChainID, DomainID, ExtractDestDomainID, ExtractRecipient, IsReserved, ResourceId,
 	VerifyingContractAddress,
 };
 use xcm::latest::{prelude::*, AssetId as XcmAssetId, MultiLocation};
@@ -380,6 +380,8 @@ parameter_types! {
 	// BridgeAccount is an account for holding transferred asset collection
 	// BridgeAccount address: 5EMepC39b7E2zfM9g6CkPp8KCAxGTh7D4w4T2tFjmjpd4tPw
 	pub BridgeAccount: AccountId32 = AccountId32::new([101u8; 32]);
+	// EIP712ChainID is the chainID that pallet is assigned with, used in EIP712 typed data domain
+	pub EIP712ChainID: ChainID = primitive_types::U256([1u64; 4]);
 	// DestVerifyingContractAddress is a H160 address that is used in proposal signature verification, specifically EIP712 typed data
 	// When relayers signing, this address will be included in the EIP712Domain
 	// As long as the relayer and pallet configured with the same address, EIP712Domain should be recognized properly.
@@ -529,6 +531,7 @@ impl sygma_bridge::Config for Runtime {
 	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type TransferReserveAccount = BridgeAccount;
 	type FeeReserveAccount = TreasuryAccount;
+	type EIP712ChainID = EIP712ChainID;
 	type DestVerifyingContractAddress = DestVerifyingContractAddress;
 	type FeeHandler = FeeHandlerRouter;
 	type AssetTransactor = AssetTransactors;

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -372,16 +372,12 @@ impl sygma_fee_handler_router::Config for Runtime {
 const DEST_VERIFYING_CONTRACT_ADDRESS: &str = "6CdE2Cd82a4F8B74693Ff5e194c19CA08c2d1c68";
 
 parameter_types! {
-	// DestDomainID is the EVM chain domainID that runtime is bridging with
-	pub DestDomainID: DomainID = 1;
 	// TreasuryAccount is an substrate account and currently used for substrate -> EVM bridging fee collection
 	// TreasuryAccount address: 5ELLU7ibt5ZrNEYRwohtaRBDBa3TzcWwwPELBPSWWd2mbgv3
 	pub TreasuryAccount: AccountId32 = AccountId32::new([100u8; 32]);
 	// BridgeAccount is an account for holding transferred asset collection
 	// BridgeAccount address: 5EMepC39b7E2zfM9g6CkPp8KCAxGTh7D4w4T2tFjmjpd4tPw
 	pub BridgeAccount: AccountId32 = AccountId32::new([101u8; 32]);
-	// DestDomainID is the EVM chainID that runtime is bridging with
-	pub DestChainID: ChainID = primitive_types::U256([1u64; 4]);
 	// DestVerifyingContractAddress is a H160 address that is used in proposal signature verification, specifically EIP712 typed data
 	// When relayers signing, this address will be included in the EIP712Domain
 	// As long as the relayer and pallet configured with the same address, EIP712Domain should be recognized properly.
@@ -517,10 +513,8 @@ impl ExtractRecipient for RecipientParser {
 impl sygma_bridge::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type DestDomainID = DestDomainID;
 	type TransferReserveAccount = BridgeAccount;
 	type FeeReserveAccount = TreasuryAccount;
-	type DestChainID = DestChainID;
 	type DestVerifyingContractAddress = DestVerifyingContractAddress;
 	type FeeHandler = FeeHandlerRouter;
 	type AssetTransactor = AssetTransactors;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -29,12 +29,8 @@ pub trait IsReserved {
 	fn is_reserved(asset_id: &AssetId) -> bool;
 }
 
-pub trait ExtractRecipient {
-	fn extract_recipient(dest: &MultiLocation) -> Option<Vec<u8>>;
-}
-
-pub trait ExtractDestDomainID {
-	fn extract_dest_domain_id(dest: &MultiLocation) -> Option<DomainID>;
+pub trait ExtractDestinationData {
+	fn extract_dest(dest: &MultiLocation) -> Option<(Vec<u8>, DomainID)>;
 }
 
 pub trait FeeHandler {

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -33,6 +33,10 @@ pub trait ExtractRecipient {
 	fn extract_recipient(dest: &MultiLocation) -> Option<Vec<u8>>;
 }
 
+pub trait ExtractDestDomainID {
+	fn extract_dest_domain_id(dest: &MultiLocation) -> Option<DomainID>;
+}
+
 pub trait FeeHandler {
 	// Return fee represent by a specific asset
 	fn get_fee(domain: DomainID, asset: &AssetId) -> Option<u128>;


### PR DESCRIPTION
- Add domainID and chainID pairs in the storage: `DestDomainIds` and `DestChainIds`
- Add extrinsic `register_domain` and `unregister_domain`
- Remove `DestDomainID`
- Rename `DestChainID` to `EIP712ChainID`
- Refactor `deposit`, `retry` and `executionProposal`, `pause_bridge`, `unpause_bridge` extrinsic logic according to the domain changes
- Add `ExtractDestDomainID` trait
- Add event `RegisterDestDomain` and `UnregisterDestDomain`
- Add unit tests
- Update e2e setup script  

close #45 