### PR TITLE
chore: New sygma concrate assets reserve checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,8 @@ dependencies = [
  "sp-timestamp",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "sygma-rpc",
+ "sygma-runtime-api",
  "try-runtime-cli",
 ]
 
@@ -3916,6 +3918,7 @@ dependencies = [
  "sygma-basic-feehandler",
  "sygma-bridge",
  "sygma-fee-handler-router",
+ "sygma-runtime-api",
  "sygma-traits",
  "xcm",
  "xcm-builder",
@@ -7696,6 +7699,31 @@ dependencies = [
  "sygma-traits",
  "xcm",
  "xcm-builder",
+]
+
+[[package]]
+name = "sygma-rpc"
+version = "0.1.0"
+dependencies = [
+ "jsonrpsee",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-rpc",
+ "scale-info",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+ "sygma-runtime-api",
+ "sygma-traits",
+]
+
+[[package]]
+name = "sygma-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "sp-api",
+ "sygma-bridge",
+ "sygma-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,8 +3869,6 @@ dependencies = [
  "sp-timestamp",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
- "sygma-rpc",
- "sygma-runtime-api",
  "try-runtime-cli",
 ]
 
@@ -3918,7 +3916,6 @@ dependencies = [
  "sygma-basic-feehandler",
  "sygma-bridge",
  "sygma-fee-handler-router",
- "sygma-runtime-api",
  "sygma-traits",
  "xcm",
  "xcm-builder",
@@ -7699,31 +7696,6 @@ dependencies = [
  "sygma-traits",
  "xcm",
  "xcm-builder",
-]
-
-[[package]]
-name = "sygma-rpc"
-version = "0.1.0"
-dependencies = [
- "jsonrpsee",
- "parity-scale-codec",
- "sc-client-api",
- "sc-rpc",
- "scale-info",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
- "sygma-runtime-api",
- "sygma-traits",
-]
-
-[[package]]
-name = "sygma-runtime-api"
-version = "0.1.0"
-dependencies = [
- "sp-api",
- "sygma-bridge",
- "sygma-traits",
 ]
 
 [[package]]

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -40,12 +40,12 @@ pub mod pallet {
 	};
 	use sp_std::{convert::From, vec, vec::Vec};
 	use xcm::latest::{prelude::*, MultiLocation};
-	use xcm_executor::traits::TransactAsset;
+	use xcm_executor::traits::{FilterAssetLocation, TransactAsset};
 
 	use crate::eip712;
 	use sygma_traits::{
-		ChainID, DepositNonce, DomainID, ExtractDestinationData, FeeHandler, IsReserved,
-		MpcAddress, ResourceId, TransferType, VerifyingContractAddress,
+		ChainID, DepositNonce, DomainID, ExtractDestinationData, FeeHandler, MpcAddress,
+		ResourceId, TransferType, VerifyingContractAddress,
 	};
 
 	#[allow(dead_code)]
@@ -100,8 +100,8 @@ pub mod pallet {
 		/// AssetId and ResourceId pairs
 		type ResourcePairs: Get<Vec<(AssetId, ResourceId)>>;
 
-		/// Return if asset reserved on current chain
-		type ReserveChecker: IsReserved;
+		/// Return true if asset reserved on current chain
+		type IsReserve: FilterAssetLocation;
 
 		/// Extract dest data from given MultiLocation
 		type ExtractDestData: ExtractDestinationData;
@@ -460,7 +460,7 @@ pub mod pallet {
 
 			// Deposit `amount - fee` of asset to reserve account if asset is reserved in local
 			// chain.
-			if T::ReserveChecker::is_reserved(&asset.id) {
+			if T::IsReserve::filter_asset_location(&asset, &MultiLocation::here()) {
 				T::AssetTransactor::deposit_asset(
 					&(asset.id.clone(), Fungible(amount - fee)).into(),
 					&Junction::AccountId32 {
@@ -770,10 +770,10 @@ pub mod pallet {
 			// Extract Receipt from proposal data to get corresponding location (MultiLocation)
 			let (amount, location) =
 				Self::extract_deposit_data(&proposal.data).ok_or(Error::<T>::InvalidDepositData)?;
-			let asset = (asset_id.clone(), amount).into();
+			let asset = (asset_id, amount).into();
 
 			// Withdraw `amount` of asset from reserve account
-			if T::ReserveChecker::is_reserved(&asset_id) {
+			if T::IsReserve::filter_asset_location(&asset, &MultiLocation::here()) {
 				T::AssetTransactor::withdraw_asset(
 					&asset,
 					&Junction::AccountId32 {

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -31,15 +31,16 @@ use sp_std::{borrow::Borrow, marker::PhantomData, prelude::*, result, vec::Vec};
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use sygma_traits::{
-	ChainID, DepositNonce, DomainID, ExtractDestinationData, IsReserved, ResourceId,
-	VerifyingContractAddress,
+	ChainID, DepositNonce, DomainID, ExtractDestinationData, ResourceId, VerifyingContractAddress,
 };
 use xcm::latest::{prelude::*, AssetId as XcmAssetId, MultiLocation};
 use xcm_builder::{
 	AccountId32Aliases, CurrencyAdapter, FungiblesAdapter, IsConcrete, ParentIsPreset,
 	SiblingParachainConvertsVia,
 };
-use xcm_executor::traits::{Convert, Error as ExecutionError, MatchesFungibles};
+use xcm_executor::traits::{
+	Convert, Error as ExecutionError, FilterAssetLocation, MatchesFungibles,
+};
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
@@ -495,10 +496,61 @@ pub type FungiblesTransactor = FungiblesAdapter<
 /// Means for transacting assets on this chain.
 pub type AssetTransactors = (CurrencyTransactor, FungiblesTransactor);
 
+pub struct ConcrateSygmaAsset;
+impl ConcrateSygmaAsset {
+	pub fn id(asset: &MultiAsset) -> Option<MultiLocation> {
+		match (&asset.id, &asset.fun) {
+			// So far our native asset is concrete
+			(Concrete(id), Fungible(_)) => Some(id.clone()),
+			_ => None,
+		}
+	}
+
+	pub fn origin(asset: &MultiAsset) -> Option<MultiLocation> {
+		Self::id(asset).and_then(|id| {
+			match (id.parents, id.first_interior()) {
+				// Sibling parachain
+				(1, Some(Parachain(id))) => {
+					// Assume current parachain id is 2004, for production, you should always get
+					// your it from parachain info
+					if *id == 2004 {
+						// The registered foreign assets actually reserved on EVM chains, so when
+						// transfer back to EVM chains, they should be treated as non-reserve assets
+						// relative to current chain.
+						Some(MultiLocation::new(
+							0,
+							X1(GeneralKey(
+								b"sygma".to_vec().try_into().expect("less than length limit; qed"),
+							)),
+						))
+					} else {
+						// Other parachain assets should be treat as reserve asset when transfered
+						// to outside EVM chains
+						Some(MultiLocation::here())
+					}
+				},
+				// Parent assets should be treat as reserve asset when transfered to outside EVM
+				// chains
+				(1, _) => Some(MultiLocation::here()),
+				// Children parachain
+				(0, Some(Parachain(id))) => Some(MultiLocation::new(0, X1(Parachain(*id)))),
+				// Local: (0, Here)
+				(0, None) => Some(id),
+				_ => None,
+			}
+		})
+	}
+}
+
 pub struct ReserveChecker;
-impl IsReserved for ReserveChecker {
-	fn is_reserved(asset_id: &XcmAssetId) -> bool {
-		asset_id == &NativeLocation::get().into()
+impl FilterAssetLocation for ReserveChecker {
+	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
+		if let Some(ref id) = ConcrateSygmaAsset::origin(asset) {
+			if id == origin {
+				return true
+			}
+		}
+		false
 	}
 }
 
@@ -524,7 +576,7 @@ impl sygma_bridge::Config for Runtime {
 	type FeeHandler = FeeHandlerRouter;
 	type AssetTransactor = AssetTransactors;
 	type ResourcePairs = ResourcePairs;
-	type ReserveChecker = ReserveChecker;
+	type IsReserve = ReserveChecker;
 	type ExtractDestData = DestinationDataParser;
 	type PalletId = SygmaBridgePalletId;
 	type PalletIndex = BridgePalletIndex;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -25,10 +25,6 @@ pub enum TransferType {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, Copy, Default)]
 pub struct MpcAddress(pub [u8; 20]);
 
-pub trait IsReserved {
-	fn is_reserved(asset_id: &AssetId) -> bool;
-}
-
 pub trait ExtractDestinationData {
 	fn extract_dest(dest: &MultiLocation) -> Option<(Vec<u8>, DomainID)>;
 }


### PR DESCRIPTION
In this PR, we change the reserve checker implementation trait from `IsReserve` defined in sygma-trait to `FilterAssetLocation` defined in [xcm-executor](https://github.com/paritytech/polkadot/blob/master/xcm/xcm-executor/src/traits/filter_asset_location.rs). In XCM (V2), this is used to check if the asset is being handled by its reserve location.

Generally, we always trust asset reserve location, for instance:
ASTR is reserved on parachain AStar, when given AStar location and ASTR multilocation, the `FilterAssetLocation` should return true, otherwise, return false.

In our scenario, Sygma as an EVM bridge will act as the bridge transfer assets between substrate chains and EVM chains. When an EVM-reserved asset (USDC) was transferred from the substrate chain to the EVM chain, `FilterAssetLocation` should return false, because the current chain is not its reserve chain; And if we transfer a parachain native asset to the EVM chain, it should return true, thus the bridge will perform deposit asset into reserve account instead of burning it directly.