### PR TITLE
fix: Remove dependencies for toolchain mem-allocator/panic-handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,15 +1552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth-encode-packed"
-version = "0.1.0"
-source = "git+https://github.com/tolak/eth-encode-packed-rs.git?branch=0.1.0-etherabi-18#90d2fe0e98232cb318771ee3ffd4fee284c7c870"
-dependencies = [
- "ethabi",
- "hex",
-]
-
-[[package]]
 name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7652,12 +7643,12 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "assert_matches",
- "eth-encode-packed",
  "ethabi",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "funty 3.0.0-rc2",
+ "hex",
  "hex-literal",
  "log",
  "pallet-assets",
@@ -8214,7 +8205,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.6",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ exclude = [
 
 [profile.release]
 panic = "unwind"
-
-[patch.crates-io]
-eth-encode-packed = { git = "https://github.com/tolak/eth-encode-packed-rs.git", branch = "0.1.0-etherabi-18" }

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -8,7 +8,6 @@ license = "LGPL-3.0"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive", "serde", "decode"] }
 log = { version = "0.4.14", default-features = false }
-# eth-encode-packed = { version =  "0.1.0", default-features = false }
 ethabi = { version = "18.0.0", default-features = false }
 primitive-types = { version = "0.12", default-features = false, features = ["scale-info", "serde_no_std"] }
 arrayref = { version = "0.3.6", default-features = false }
@@ -70,7 +69,6 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"log/std",
-	# "eth-encode-packed/std",
 	"ethabi/std",
 	"hex/std",
 	"primitive-types/std",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -8,14 +8,15 @@ license = "LGPL-3.0"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive", "serde", "decode"] }
 log = { version = "0.4.14", default-features = false }
-eth-encode-packed = { version =  "0.1.0", default-features = false }
+# eth-encode-packed = { version =  "0.1.0", default-features = false }
 ethabi = { version = "18.0.0", default-features = false }
 primitive-types = { version = "0.12", default-features = false, features = ["scale-info", "serde_no_std"] }
 arrayref = { version = "0.3.6", default-features = false }
 funty = { version = "3.0.0-rc1", default-features = false }
+hex = {version = "0.4.3", default-features = false, features = ["alloc"] }
 
 # Substrate
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
@@ -69,9 +70,10 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"log/std",
+	# "eth-encode-packed/std",
 	"ethabi/std",
+	"hex/std",
 	"primitive-types/std",
-	"sp-std/std",
 	"sp-runtime/std",
 	"sp-io/std",
 	"sp-std/std",

--- a/bridge/src/abi.rs
+++ b/bridge/src/abi.rs
@@ -1,0 +1,70 @@
+// The Licensed Work is (c) 2022 Sygma
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/// Port from https://github.com/roberts-ivanovs/eth-encode-packed-rs
+use ethabi::ethereum_types::{Address, U256};
+
+pub struct TakeLastXBytes(pub usize);
+
+pub enum SolidityDataType<'a> {
+	String(&'a str),
+	Address(Address),
+	Bytes(&'a [u8]),
+	Bool(bool),
+	Number(U256),
+	NumberWithShift(U256, TakeLastXBytes),
+}
+
+pub mod abi {
+	use super::SolidityDataType;
+	use sp_std::{vec, vec::Vec};
+
+	/// Pack a single `SolidityDataType` into bytes
+	fn pack<'a>(data_type: &'a SolidityDataType) -> Vec<u8> {
+		let mut res = Vec::new();
+		match data_type {
+			SolidityDataType::String(s) => {
+				res.extend(s.as_bytes());
+			},
+			SolidityDataType::Address(a) => {
+				res.extend(a.0);
+			},
+			SolidityDataType::Number(n) =>
+				for b in n.0.iter().rev() {
+					let bytes = b.to_be_bytes();
+					res.extend(bytes);
+				},
+			SolidityDataType::Bytes(b) => {
+				res.extend(*b);
+			},
+			SolidityDataType::Bool(b) =>
+				if *b {
+					res.push(1);
+				} else {
+					res.push(0);
+				},
+			SolidityDataType::NumberWithShift(n, to_take) => {
+				let local_res = n.0.iter().rev().fold(vec![], |mut acc, i| {
+					let bytes = i.to_be_bytes();
+					acc.extend(bytes);
+					acc
+				});
+
+				let to_skip = local_res.len() - (to_take.0 / 8);
+				let local_res = local_res.into_iter().skip(to_skip).collect::<Vec<u8>>();
+				res.extend(local_res);
+			},
+		};
+		return res
+	}
+
+	pub fn encode_packed(items: &[SolidityDataType]) -> Vec<u8> {
+		let res = items.iter().fold(Vec::new(), |mut acc, i| {
+			let pack = pack(i);
+			acc.push(pack);
+			acc
+		});
+		let res = res.join(&[][..]);
+		res
+	}
+}

--- a/bridge/src/eip712.rs
+++ b/bridge/src/eip712.rs
@@ -1,7 +1,6 @@
 // The Licensed Work is (c) 2022 Sygma
 // SPDX-License-Identifier: LGPL-3.0-only
 
-use alloc::{string::String, vec};
 /// Port from https://github.com/gakonst/ethers-rs/blob/master/ethers-core/src/types/transaction/eip712.rs
 /// Replace hash provided by `sp_io`
 use ethabi::{
@@ -10,6 +9,7 @@ use ethabi::{
 	token::Token,
 };
 use sp_io::hashing::keccak_256;
+use sp_std::{vec, vec::Vec};
 
 /// Pre-computed value of the following statement:
 ///
@@ -34,11 +34,11 @@ pub const EIP712_DOMAIN_TYPE_HASH_WITH_SALT: [u8; 32] = [
 #[derive(Debug, Default, Clone)]
 pub struct EIP712Domain {
 	///  The user readable name of signing domain, i.e. the name of the DApp or the protocol.
-	pub name: String,
+	pub name: Vec<u8>,
 
 	/// The current major version of the signing domain. Signatures from different versions are not
 	/// compatible.
-	pub version: String,
+	pub version: Vec<u8>,
 
 	/// The EIP-155 chain id. The user-agent should refuse signing if it does not match the
 	/// currently active chain.
@@ -64,8 +64,8 @@ impl EIP712Domain {
 
 		let mut tokens = vec![
 			Token::Uint(U256::from(domain_type_hash)),
-			Token::Uint(U256::from(keccak_256(self.name.as_bytes()))),
-			Token::Uint(U256::from(keccak_256(self.version.as_bytes()))),
+			Token::Uint(U256::from(keccak_256(&self.name))),
+			Token::Uint(U256::from(keccak_256(&self.version))),
 			Token::Uint(self.chain_id),
 			Token::Address(self.verifying_contract),
 		];

--- a/bridge/src/encode.rs
+++ b/bridge/src/encode.rs
@@ -6,6 +6,7 @@ use ethabi::ethereum_types::{Address, U256};
 
 pub struct TakeLastXBytes(pub usize);
 
+#[allow(dead_code)]
 pub enum SolidityDataType<'a> {
 	String(&'a str),
 	Address(Address),
@@ -20,6 +21,7 @@ pub mod abi {
 	use sp_std::{vec, vec::Vec};
 
 	/// Pack a single `SolidityDataType` into bytes
+	#[allow(clippy::needless_lifetimes)]
 	fn pack<'a>(data_type: &'a SolidityDataType) -> Vec<u8> {
 		let mut res = Vec::new();
 		match data_type {
@@ -55,7 +57,7 @@ pub mod abi {
 				res.extend(local_res);
 			},
 		};
-		return res
+		res
 	}
 
 	pub fn encode_packed(items: &[SolidityDataType]) -> Vec<u8> {
@@ -64,7 +66,6 @@ pub mod abi {
 			acc.push(pack);
 			acc
 		});
-		let res = res.join(&[][..]);
-		res
+		res.join(&[][..])
 	}
 }

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -8,8 +8,8 @@ extern crate arrayref;
 
 pub use self::pallet::*;
 
-mod abi;
 mod eip712;
+mod encode;
 
 #[cfg(test)]
 mod mock;
@@ -18,7 +18,7 @@ mod mock;
 #[allow(clippy::large_enum_variant)]
 #[frame_support::pallet]
 pub mod pallet {
-	use crate::abi::{abi::encode_packed, SolidityDataType};
+	use crate::encode::{abi::encode_packed, SolidityDataType};
 	use codec::{Decode, Encode};
 	use ethabi::{encode as abi_encode, token::Token};
 	use frame_support::{

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -6,11 +6,11 @@
 #[macro_use]
 extern crate arrayref;
 
-extern crate alloc;
-
 pub use self::pallet::*;
 
+mod abi;
 mod eip712;
+
 #[cfg(test)]
 mod mock;
 
@@ -18,10 +18,8 @@ mod mock;
 #[allow(clippy::large_enum_variant)]
 #[frame_support::pallet]
 pub mod pallet {
-	use alloc::string::String;
-
+	use crate::abi::{abi::encode_packed, SolidityDataType};
 	use codec::{Decode, Encode};
-	use eth_encode_packed::{abi::encode_packed, SolidityDataType};
 	use ethabi::{encode as abi_encode, token::Token};
 	use frame_support::{
 		dispatch::DispatchResult, pallet_prelude::*, traits::StorageVersion, transactional,
@@ -647,7 +645,7 @@ pub mod pallet {
 			}
 
 			let final_keccak_data_input = &vec![SolidityDataType::Bytes(&final_keccak_data)];
-			let (bytes, _) = encode_packed(final_keccak_data_input);
+			let bytes = encode_packed(final_keccak_data_input);
 			let hashed_keccak_data = keccak_256(bytes.as_slice());
 
 			let struct_hash = keccak_256(&abi_encode(&[
@@ -658,8 +656,8 @@ pub mod pallet {
 			// domain separator
 			let default_eip712_domain = eip712::EIP712Domain::default();
 			let eip712_domain = eip712::EIP712Domain {
-				name: String::from("Bridge"),
-				version: String::from("3.1.0"),
+				name: b"Bridge".to_vec(),
+				version: b"3.1.0".to_vec(),
 				chain_id: T::EIP712ChainID::get(),
 				verifying_contract: T::DestVerifyingContractAddress::get(),
 				salt: default_eip712_domain.salt,
@@ -671,7 +669,7 @@ pub mod pallet {
 				SolidityDataType::Bytes(&domain_separator),
 				SolidityDataType::Bytes(&struct_hash),
 			];
-			let (bytes, _) = encode_packed(typed_data_hash_input);
+			let bytes = encode_packed(typed_data_hash_input);
 			keccak_256(bytes.as_slice())
 		}
 
@@ -800,7 +798,6 @@ pub mod pallet {
 			DestChainIds, DestDomainIds, Error, Event as SygmaBridgeEvent, IsPaused, MpcAddr,
 			Proposal,
 		};
-		use alloc::vec;
 		use bridge::mock::{
 			assert_events, new_test_ext, AccessSegregator, Assets, Balances, BridgeAccount,
 			BridgePalletIndex, NativeLocation, NativeResourceId, Runtime, RuntimeEvent,
@@ -816,7 +813,7 @@ pub mod pallet {
 		use primitive_types::U256;
 		use sp_core::{ecdsa, Pair};
 		use sp_runtime::WeakBoundedVec;
-		use sp_std::convert::TryFrom;
+		use sp_std::{convert::TryFrom, vec};
 		use sygma_traits::{MpcAddress, TransferType};
 		use xcm::latest::prelude::*;
 


### PR DESCRIPTION
This PR fixes a potential bug that may happen on parachains that integrate the Sygma pallet into their runtime. I found this when I did the integration on Phala. Let me explain what the bug is:

Sygma bridge pallet has some stuff about EIP712, which then introduced dependency [eth-encode-packed-rs](https://github.com/roberts-ivanovs/eth-encode-packed-rs) (before this PR we actually patch it because we have some random issue before, that's another thing). This package is not dedicated to writing for a pure WASM runtime environment, so in this package, they used types like `String`, and `Vec` which both rely on the memory allocator provided by rust toolchain.

However, substrate pallet `sp-io` also provides a global memory allocator for WASM runtime, so when building pallets for `no-std` env (e.g. WASM), Sygma pallets will have two allocators at the same time, rust compiler will not let this happen, then it will fail to compile with an error like `duplicate lang item in crate ...`. When I got this error when I build Sygma pallet serval months ago, instead of removing the dependencies of the rust toolchain allocator from `eth-encode-packed-rs`, I chose to disable the allocator provided `sp-io`(I don't know that will bring an issue that time).
```
sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
```
So when I did this, the build was passed, and everything was good, even when we ran a node template locally which I suppose actually hasn't run in WASM mode. But the problem is thrown when I run it in a parachain environment. The issue is when we run it on WASM mode, some functions of the std allocator don't have a real implementation, they may just be an empty body to let compiling pass (WASM somehow too early). Finally, I got the runtime error which should have been fixed in compiling time:
```
message: "wasm trap: out of bounds memory access"
```

Now we know that disabling the allocator in `sp-io` is not a good idea, so in this PR, I port code from `eth-encode-packed-rs` and did some changes to the code to let it don't rely on the toolchain allocator any more. The problem with our parachain was also solved.
