### PR TITLE
chore: Use rust Box construct big extrinsic parameters

### DIFF
--- a/basic-fee-handler/src/lib.rs
+++ b/basic-fee-handler/src/lib.rs
@@ -14,6 +14,7 @@ mod mock;
 pub mod pallet {
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*, traits::StorageVersion};
 	use frame_system::pallet_prelude::*;
+	use sp_std::boxed::Box;
 	use sygma_traits::{DomainID, FeeHandler};
 	use xcm::latest::AssetId;
 
@@ -65,9 +66,10 @@ pub mod pallet {
 		pub fn set_fee(
 			origin: OriginFor<T>,
 			domain: DomainID,
-			asset: AssetId,
+			asset: Box<AssetId>,
 			amount: u128,
 		) -> DispatchResult {
+			let asset: AssetId = *asset;
 			if <T as Config>::BridgeCommitteeOrigin::ensure_origin(origin.clone()).is_err() {
 				// Ensure bridge committee or the account that has permisson to set fee
 				let who = ensure_signed(origin)?;
@@ -105,6 +107,7 @@ pub mod pallet {
 			RuntimeEvent as Event, RuntimeOrigin as Origin, Test, ALICE,
 		};
 		use frame_support::{assert_noop, assert_ok};
+		use sp_std::boxed::Box;
 		use sygma_traits::DomainID;
 		use xcm::latest::{prelude::*, MultiLocation};
 
@@ -123,14 +126,14 @@ pub mod pallet {
 				assert_ok!(BasicFeeHandler::set_fee(
 					Origin::root(),
 					dest_domain_id,
-					asset_id_a.clone(),
+					Box::new(asset_id_a.clone()),
 					amount_a
 				));
 				// set fee 200 with assetId asset_id_a for another domain
 				assert_ok!(BasicFeeHandler::set_fee(
 					Origin::root(),
 					another_dest_domain_id,
-					asset_id_a.clone(),
+					Box::new(asset_id_a.clone()),
 					amount_a * 2
 				));
 				assert_eq!(
@@ -146,7 +149,7 @@ pub mod pallet {
 				assert_ok!(BasicFeeHandler::set_fee(
 					Origin::root(),
 					dest_domain_id,
-					asset_id_b.clone(),
+					Box::new(asset_id_b.clone()),
 					amount_b
 				));
 				assert_eq!(
@@ -172,7 +175,7 @@ pub mod pallet {
 					BasicFeeHandler::set_fee(
 						unauthorized_account,
 						dest_domain_id,
-						asset_id_a.clone(),
+						Box::new(asset_id_a.clone()),
 						amount_a
 					),
 					basic_fee_handler::Error::<Test>::AccessDenied
@@ -207,14 +210,14 @@ pub mod pallet {
 				assert_ok!(BasicFeeHandler::set_fee(
 					Origin::root(),
 					dest_domain_id,
-					asset_id.clone(),
+					Box::new(asset_id.clone()),
 					100
 				),);
 				assert_noop!(
 					BasicFeeHandler::set_fee(
 						Some(ALICE).into(),
 						dest_domain_id,
-						asset_id.clone(),
+						Box::new(asset_id.clone()),
 						200
 					),
 					basic_fee_handler::Error::<Test>::AccessDenied
@@ -240,7 +243,7 @@ pub mod pallet {
 				assert_ok!(BasicFeeHandler::set_fee(
 					Some(ALICE).into(),
 					dest_domain_id,
-					asset_id.clone(),
+					Box::new(asset_id.clone()),
 					200
 				),);
 				assert_eq!(AssetFees::<Test>::get(&(dest_domain_id, asset_id)).unwrap(), 200);

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -1137,7 +1137,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				assert_ok!(SygmaBridge::register_domain(
@@ -1235,7 +1235,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					UsdcLocation::get().into(),
+					Box::new(UsdcLocation::get().into()),
 					fee
 				));
 				assert_ok!(SygmaBridge::register_domain(
@@ -1307,7 +1307,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					unbounded_asset_location.clone().into(),
+					Box::new(unbounded_asset_location.clone().into()),
 					fee
 				));
 				assert_ok!(SygmaBridge::register_domain(
@@ -1359,7 +1359,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				assert_ok!(SygmaBridge::register_domain(
@@ -1424,7 +1424,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				assert_ok!(SygmaBridge::register_domain(
@@ -1466,7 +1466,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				// register domain
@@ -1531,7 +1531,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				assert_noop!(
@@ -1639,7 +1639,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				assert_ok!(SygmaBridge::deposit(
@@ -1994,19 +1994,19 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee_native_asset
 				));
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					UsdcLocation::get().into(),
+					Box::new(UsdcLocation::get().into()),
 					fee_usdc_asset
 				));
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					AstrLocation::get().into(),
+					Box::new(AstrLocation::get().into()),
 					fee_astr_asset
 				));
 
@@ -2189,7 +2189,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					AstrLocation::get().into(),
+					Box::new(AstrLocation::get().into()),
 					fee_astr_asset_extreme_small_amount
 				));
 				// after decimal conversion from 24 to 18, the final amount will be 0 so that
@@ -2242,7 +2242,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					DEST_DOMAIN_ID,
-					NativeLocation::get().into(),
+					Box::new(NativeLocation::get().into()),
 					fee
 				));
 				// deposit in advance to make sure the native asset has enough funds in

--- a/fee-handler-router/src/lib.rs
+++ b/fee-handler-router/src/lib.rs
@@ -14,6 +14,7 @@ mod mock;
 pub mod pallet {
 	use frame_support::{pallet_prelude::*, traits::StorageVersion};
 	use frame_system::pallet_prelude::*;
+	use sp_std::boxed::Box;
 	use sygma_traits::{DomainID, FeeHandler};
 	use xcm::latest::AssetId;
 
@@ -76,9 +77,10 @@ pub mod pallet {
 		pub fn set_fee_handler(
 			origin: OriginFor<T>,
 			domain: DomainID,
-			asset: AssetId,
+			asset: Box<AssetId>,
 			handler_type: FeeHandlerType,
 		) -> DispatchResult {
+			let asset: AssetId = *asset;
 			if <T as Config>::BridgeCommitteeOrigin::ensure_origin(origin.clone()).is_err() {
 				// Ensure bridge committee or the account that has permisson to set fee
 				let who = ensure_signed(origin)?;
@@ -128,6 +130,7 @@ pub mod pallet {
 			RuntimeOrigin as Origin, SygmaBasicFeeHandler, Test, ALICE,
 		};
 		use frame_support::{assert_noop, assert_ok};
+		use sp_std::boxed::Box;
 		use sygma_traits::FeeHandler;
 		use xcm::latest::prelude::*;
 
@@ -139,14 +142,14 @@ pub mod pallet {
 				assert_ok!(FeeHandlerRouter::set_fee_handler(
 					Origin::root(),
 					EthereumDomainID::get(),
-					asset_id.clone(),
+					Box::new(asset_id.clone()),
 					FeeHandlerType::BasicFeeHandler,
 				));
 				assert_noop!(
 					FeeHandlerRouter::set_fee_handler(
 						Some(ALICE).into(),
 						EthereumDomainID::get(),
-						asset_id.clone(),
+						Box::new(asset_id.clone()),
 						FeeHandlerType::BasicFeeHandler,
 					),
 					fee_router::Error::<Test>::AccessDenied
@@ -172,7 +175,7 @@ pub mod pallet {
 				assert_ok!(FeeHandlerRouter::set_fee_handler(
 					Some(ALICE).into(),
 					MoonbeamDomainID::get(),
-					asset_id.clone(),
+					Box::new(asset_id.clone()),
 					FeeHandlerType::DynamicFeeHandler,
 				),);
 				assert_eq!(
@@ -189,14 +192,14 @@ pub mod pallet {
 				assert_ok!(FeeHandlerRouter::set_fee_handler(
 					Origin::root(),
 					EthereumDomainID::get(),
-					PhaLocation::get().into(),
+					Box::new(PhaLocation::get().into()),
 					FeeHandlerType::BasicFeeHandler,
 				));
 				// config dest of (moonbeam, PHA) use dyncmic fee handler
 				assert_ok!(FeeHandlerRouter::set_fee_handler(
 					Origin::root(),
 					MoonbeamDomainID::get(),
-					PhaLocation::get().into(),
+					Box::new(PhaLocation::get().into()),
 					FeeHandlerType::DynamicFeeHandler,
 				));
 
@@ -204,7 +207,7 @@ pub mod pallet {
 				assert_ok!(SygmaBasicFeeHandler::set_fee(
 					Origin::root(),
 					EthereumDomainID::get(),
-					PhaLocation::get().into(),
+					Box::new(PhaLocation::get().into()),
 					10000
 				));
 


### PR DESCRIPTION
This PR is going to fix a potential test issue that happened when the parachain has many pallets in their runtime. The problem is when parachain constructs a runtime call with macro `construct_runtime!` in runtime.rs with too many pallets and big extrinsic parameters, it will lead to **integration test failure** thrown by this [line](https://github.com/paritytech/substrate/blob/0d36e75bde372b297d9a4c3deb4dd9a42b756bc2/frame/utility/src/lib.rs#L151), that is because the substrate has a limit for the maximum enum size (currently is 1024 bytes), a best practice for pallet implementation is always using rust `Box` construct big extrinsic parameters which will allocate the data on the heap instead of the stack.