### PR TITLE
fix: avoid panic with invalid proposal data

### DIFF
--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -738,24 +738,24 @@ pub mod pallet {
 		/// Only fungible transfer is supported so far.
 		fn extract_deposit_data(data: &Vec<u8>) -> Result<(u128, MultiLocation), Error<T>> {
 			if data.len() < 64 {
-					return Err(Error::<T>::InvalidDepositData);
+				return Err(Error::<T>::InvalidDepositData)
 			}
 
 			let amount: u128 = match U256::from_big_endian(&data[0..32]).try_into() {
-					Ok(v) => v,
-					Err(_) => return Err(Error::<T>::InvalidDepositData),
+				Ok(v) => v,
+				Err(_) => return Err(Error::<T>::InvalidDepositData),
 			};
 			let recipient_len: usize = match U256::from_big_endian(&data[32..64]).try_into() {
-					Ok(v) => v,
-					Err(_) => return Err(Error::<T>::InvalidDepositData),
+				Ok(v) => v,
+				Err(_) => return Err(Error::<T>::InvalidDepositData),
 			};
 			if (data.len() - 64) != recipient_len {
-					return Err(Error::<T>::InvalidDepositData);
+				return Err(Error::<T>::InvalidDepositData)
 			}
 
 			let recipient = data[64..data.len()].to_vec();
 			if let Ok(location) = <MultiLocation>::decode(&mut recipient.as_slice()) {
-					Ok((amount, location))
+				Ok((amount, location))
 			} else {
 				Err(Error::<T>::InvalidDepositData)
 			}
@@ -1674,7 +1674,7 @@ pub mod pallet {
 					invalid_domainid_proposal,
 					invalid_resourceid_proposal,
 					invalid_recipient_proposal,
-					empty_data_proposal
+					empty_data_proposal,
 				];
 
 				let final_message = SygmaBridge::construct_ecdsa_signing_proposals_data(&proposals);

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -736,24 +736,28 @@ pub mod pallet {
 		/// recipient data            bytes       bytes  64 - END
 		///
 		/// Only fungible transfer is supported so far.
-		fn extract_deposit_data(data: &Vec<u8>) -> Option<(u128, MultiLocation)> {
+		fn extract_deposit_data(data: &Vec<u8>) -> Result<(u128, MultiLocation), Error<T>> {
 			if data.len() < 64 {
-				return None
+					return Err(Error::<T>::InvalidDepositData);
 			}
-			let amount: u128 = U256::from_big_endian(&data[0..32])
-				.try_into()
-				.expect("Amount convert failed. qed.");
-			let recipient_len: usize = U256::from_big_endian(&data[32..64])
-				.try_into()
-				.expect("Length convert failed. qed.");
-			if data.len() != (64 + recipient_len) {
-				return None
+
+			let amount: u128 = match U256::from_big_endian(&data[0..32]).try_into() {
+					Ok(v) => v,
+					Err(_) => return Err(Error::<T>::InvalidDepositData),
+			};
+			let recipient_len: usize = match U256::from_big_endian(&data[32..64]).try_into() {
+					Ok(v) => v,
+					Err(_) => return Err(Error::<T>::InvalidDepositData),
+			};
+			if (data.len() - 64) != recipient_len {
+					return Err(Error::<T>::InvalidDepositData);
 			}
+
 			let recipient = data[64..data.len()].to_vec();
 			if let Ok(location) = <MultiLocation>::decode(&mut recipient.as_slice()) {
-				Some((amount, location))
+					Ok((amount, location))
 			} else {
-				None
+				Err(Error::<T>::InvalidDepositData)
 			}
 		}
 
@@ -800,8 +804,7 @@ pub mod pallet {
 			let asset_id =
 				Self::rid_to_assetid(&proposal.resource_id).ok_or(Error::<T>::AssetNotBound)?;
 			// Extract Receipt from proposal data to get corresponding location (MultiLocation)
-			let (amount, location) =
-				Self::extract_deposit_data(&proposal.data).ok_or(Error::<T>::InvalidDepositData)?;
+			let (amount, location) = Self::extract_deposit_data(&proposal.data)?;
 
 			// convert the asset decimal
 			let decimal_converted_asset =
@@ -1657,6 +1660,12 @@ pub mod pallet {
 					resource_id: NativeResourceId::get(),
 					data: SygmaBridge::create_deposit_data(amount, b"invalid recipient".to_vec()),
 				};
+				let empty_data_proposal = Proposal {
+					origin_domain_id: DEST_DOMAIN_ID,
+					deposit_nonce: 3,
+					resource_id: UsdcResourceId::get(),
+					data: vec![],
+				};
 
 				let proposals = vec![
 					valid_native_transfer_proposal,
@@ -1665,6 +1674,7 @@ pub mod pallet {
 					invalid_domainid_proposal,
 					invalid_resourceid_proposal,
 					invalid_recipient_proposal,
+					empty_data_proposal
 				];
 
 				let final_message = SygmaBridge::construct_ecdsa_signing_proposals_data(&proposals);


### PR DESCRIPTION
Refactored `extract_deposit_data` function to return a result or an error to avoid triggering panic with expect call when invalid proposal data is sent.

Closes: #90  