### PR TITLE
chore: refactor boilerplate access control code

### DIFF
--- a/access-segregator/src/lib.rs
+++ b/access-segregator/src/lib.rs
@@ -152,7 +152,7 @@ pub mod pallet {
 					Some(ALICE).into()
 				));
 
-				// ALICE grants access permission to BOB for an e xtrinsic (PalletIndex::get(),
+				// ALICE grants access permission to BOB for an extrinsic (PalletIndex::get(),
 				// "unknown_extrinsic")
 				assert_ok!(AccessSegregator::grant_access(
 					Some(ALICE).into(),

--- a/basic-fee-handler/src/lib.rs
+++ b/basic-fee-handler/src/lib.rs
@@ -69,18 +69,14 @@ pub mod pallet {
 			amount: u128,
 		) -> DispatchResult {
 			let asset: AssetId = *asset;
-			if <T as Config>::BridgeCommitteeOrigin::ensure_origin(origin.clone()).is_err() {
-				// Ensure bridge committee or the account that has permisson to set fee
-				let who = ensure_signed(origin)?;
-				ensure!(
-					<sygma_access_segregator::pallet::Pallet<T>>::has_access(
-						<T as Config>::PalletIndex::get(),
-						b"set_fee".to_vec(),
-						who
-					),
-					Error::<T>::AccessDenied
-				);
-			}
+			ensure!(
+				<sygma_access_segregator::pallet::Pallet<T>>::has_access(
+					<T as Config>::PalletIndex::get(),
+					b"set_fee".to_vec(),
+					origin
+				),
+				Error::<T>::AccessDenied
+			);
 
 			// Update asset fee
 			AssetFees::<T>::insert((domain, &asset), amount);
@@ -214,7 +210,7 @@ pub mod pallet {
 				assert!(!AccessSegregator::has_access(
 					FeeHandlerPalletIndex::get(),
 					b"set_fee".to_vec(),
-					ALICE
+					Some(ALICE).into()
 				));
 				assert_ok!(AccessSegregator::grant_access(
 					Origin::root(),
@@ -225,7 +221,7 @@ pub mod pallet {
 				assert!(AccessSegregator::has_access(
 					FeeHandlerPalletIndex::get(),
 					b"set_fee".to_vec(),
-					ALICE
+					Some(ALICE).into()
 				));
 				assert_ok!(BasicFeeHandler::set_fee(
 					Some(ALICE).into(),

--- a/fee-handler-router/src/lib.rs
+++ b/fee-handler-router/src/lib.rs
@@ -80,18 +80,14 @@ pub mod pallet {
 			handler_type: FeeHandlerType,
 		) -> DispatchResult {
 			let asset: AssetId = *asset;
-			if <T as Config>::BridgeCommitteeOrigin::ensure_origin(origin.clone()).is_err() {
-				// Ensure bridge committee or the account that has permisson to set fee
-				let who = ensure_signed(origin)?;
-				ensure!(
-					<sygma_access_segregator::pallet::Pallet<T>>::has_access(
-						<T as Config>::PalletIndex::get(),
-						b"set_fee_handler".to_vec(),
-						who
-					),
-					Error::<T>::AccessDenied
-				);
-			}
+			ensure!(
+				<sygma_access_segregator::pallet::Pallet<T>>::has_access(
+					<T as Config>::PalletIndex::get(),
+					b"set_fee_handler".to_vec(),
+					origin
+				),
+				Error::<T>::AccessDenied
+			);
 
 			// Update fee handler
 			HandlerType::<T>::insert((domain, &asset), &handler_type);
@@ -158,7 +154,7 @@ pub mod pallet {
 				assert!(!AccessSegregator::has_access(
 					FeeHandlerRouterPalletIndex::get(),
 					b"set_fee_handler".to_vec(),
-					ALICE
+					Some(ALICE).into()
 				));
 				assert_ok!(AccessSegregator::grant_access(
 					Origin::root(),
@@ -169,7 +165,7 @@ pub mod pallet {
 				assert!(AccessSegregator::has_access(
 					FeeHandlerRouterPalletIndex::get(),
 					b"set_fee_handler".to_vec(),
-					ALICE
+					Some(ALICE).into()
 				));
 				assert_ok!(FeeHandlerRouter::set_fee_handler(
 					Some(ALICE).into(),


### PR DESCRIPTION
Refactor boilerplate access control code into access control segregator function `has_access`.

Closes: #95 