### PR TITLE
fix: avoid without storage info macro

### DIFF
--- a/access-segregator/src/lib.rs
+++ b/access-segregator/src/lib.rs
@@ -22,11 +22,11 @@ pub mod pallet {
 	/// (pallet_index, extrinsic_name) => account
 	#[pallet::storage]
 	#[pallet::getter(fn extrinsic_access)]
+	#[pallet::unbounded]
 	pub type ExtrinsicAccess<T: Config> = StorageMap<_, Twox64Concat, (u8, Vec<u8>), T::AccountId>;
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/basic-fee-handler/src/lib.rs
+++ b/basic-fee-handler/src/lib.rs
@@ -27,7 +27,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -62,7 +62,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/fee-handler-router/src/lib.rs
+++ b/fee-handler-router/src/lib.rs
@@ -18,7 +18,7 @@ pub mod pallet {
 	use sygma_traits::{DomainID, FeeHandler};
 	use xcm::latest::AssetId;
 
-	#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug)]
+	#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug, MaxEncodedLen)]
 	pub enum FeeHandlerType {
 		BasicFeeHandler,
 		DynamicFeeHandler,
@@ -28,7 +28,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::dispatch::TypeInfo;
 use primitive_types::{H160, U256};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -22,7 +22,20 @@ pub enum TransferType {
 	GenericTransfer,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, Copy, Default, MaxEncodedLen)]
+#[derive(
+	Clone,
+	Eq,
+	PartialEq,
+	Ord,
+	PartialOrd,
+	Debug,
+	Encode,
+	Decode,
+	TypeInfo,
+	Copy,
+	Default,
+	MaxEncodedLen,
+)]
 pub struct MpcAddress(pub [u8; 20]);
 
 pub trait ExtractDestinationData {

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -3,7 +3,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::dispatch::TypeInfo;
 use primitive_types::{H160, U256};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
@@ -22,7 +23,7 @@ pub enum TransferType {
 	GenericTransfer,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, Copy, Default)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, Copy, Default, MaxEncodedLen)]
 pub struct MpcAddress(pub [u8; 20]);
 
 pub trait ExtractDestinationData {


### PR DESCRIPTION
Remove without storage info substrate macro.

Closes: #94 