### PR TITLE
feat: Remove BridgeCommitteeOrigin from some pallets' config

### DIFF
--- a/basic-fee-handler/src/lib.rs
+++ b/basic-fee-handler/src/lib.rs
@@ -42,9 +42,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + sygma_access_segregator::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// Origin used to administer the pallet
-		type BridgeCommitteeOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-
 		/// Current pallet index defined in runtime
 		type PalletIndex: Get<u8>;
 

--- a/basic-fee-handler/src/mock.rs
+++ b/basic-fee-handler/src/mock.rs
@@ -144,7 +144,6 @@ impl sygma_access_segregator::Config for Test {
 
 impl basic_fee_handler::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = EnsureRoot<Self::AccountId>;
 	type PalletIndex = FeeHandlerPalletIndex;
 	type WeightInfo = basic_fee_handler::weights::SygmaWeightInfo<Test>;
 }

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -83,9 +83,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + sygma_access_segregator::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// Origin used to administer the pallet
-		type BridgeCommitteeOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-
 		/// Bridge transfer reserve account
 		#[pallet::constant]
 		type TransferReserveAccount: Get<Self::AccountId>;

--- a/bridge/src/mock.rs
+++ b/bridge/src/mock.rs
@@ -180,7 +180,6 @@ impl sygma_access_segregator::Config for Runtime {
 
 impl sygma_basic_feehandler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type PalletIndex = FeeHandlerPalletIndex;
 	type WeightInfo = sygma_basic_feehandler::weights::SygmaWeightInfo<Runtime>;
 }
@@ -471,7 +470,6 @@ impl ExtractDestinationData for DestinationDataParser {
 
 impl sygma_bridge::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type TransferReserveAccount = BridgeAccount;
 	type FeeReserveAccount = TreasuryAccount;
 	type EIP712ChainID = EIP712ChainID;

--- a/fee-handler-router/src/lib.rs
+++ b/fee-handler-router/src/lib.rs
@@ -43,9 +43,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + sygma_basic_feehandler::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// Origin used to administer the pallet
-		type BridgeCommitteeOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-
 		/// Fee handlers
 		type BasicFeeHandler: FeeHandler;
 		type DynamicFeeHandler: FeeHandler;

--- a/fee-handler-router/src/mock.rs
+++ b/fee-handler-router/src/mock.rs
@@ -143,7 +143,6 @@ parameter_types! {
 
 impl sygma_basic_feehandler::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = EnsureRoot<Self::AccountId>;
 	type PalletIndex = FeeHandlerPalletIndex;
 	type WeightInfo = sygma_basic_feehandler::weights::SygmaWeightInfo<Test>;
 }
@@ -158,7 +157,6 @@ impl sygma_access_segregator::Config for Test {
 
 impl fee_handler_router::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = EnsureRoot<Self::AccountId>;
 	type BasicFeeHandler = SygmaBasicFeeHandler;
 	type DynamicFeeHandler = ();
 	type PalletIndex = FeeHandlerRouterPalletIndex;

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -364,14 +364,12 @@ impl sygma_access_segregator::Config for Runtime {
 
 impl sygma_basic_feehandler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type PalletIndex = FeeHandlerPalletIndex;
 	type WeightInfo = sygma_basic_feehandler::weights::SygmaWeightInfo<Runtime>;
 }
 
 impl sygma_fee_handler_router::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BasicFeeHandler = SygmaBasicFeeHandler;
 	type DynamicFeeHandler = ();
 	type PalletIndex = FeeHandlerRouterPalletIndex;
@@ -701,7 +699,6 @@ impl ExtractDestinationData for DestinationDataParser {
 
 impl sygma_bridge::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type BridgeCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type TransferReserveAccount = BridgeAccount;
 	type FeeReserveAccount = TreasuryAccount;
 	type EIP712ChainID = EIP712ChainID;


### PR DESCRIPTION
Since all permission management is handled by pallet access-segregator, `BridgeCommitteeOrigin` is not used in bridge/fee-handler/fee-handler-router pallets anymore. This PR is going to remove the unused `BridgeCommitteeOrigin` from those pallets